### PR TITLE
updated version with working PyPi requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changes
 =======
 
+0.2-rc1+1 (September 09, 2010)
+------------------------------
+
+- Bump version number to 0.2-rc1+1
+- require GitPython==0.1.7 (lower versions aren't available on PyPi any
+  more)
+
+  - dev-requirements.txt
+  - pavement.py
+
 0.2-rc1 (April 24, 2010)
 ------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ This extension and its dependencies require:
 
  * a GitHub user account and,
  * Git (tested with 1.6.2.4),
+ * GitPython 0.1.7
  * Python 2.5+.
  
 It currently has only been tested on Ubuntu 8.04 (and Git built from source)

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Requirements
 This extension and its dependencies require:
 
  * a GitHub user account and,
- * Git (tested with 1.6.2.4), 
+ * Git (tested with 1.6.2.4),
  * Python 2.5+.
  
 It currently has only been tested on Ubuntu 8.04 (and Git built from source)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 simplejson
 Sphinx
-GitPython==0.1.6
+GitPython==0.1.7
 Mock>=0.5.0
 Nose>=0.10.4
 setuptools>=0.6c9

--- a/pavement.py
+++ b/pavement.py
@@ -54,7 +54,7 @@ classifiers = [
 
 install_requires = [
     'setuptools>=0.6c9',
-    'GitPython==0.1.6',
+    'GitPython==0.1.7',
     'Sphinx',
     'simplejson',
     ]

--- a/pavement.py
+++ b/pavement.py
@@ -36,7 +36,7 @@ def write_file(file_path, content=()):
         f.close()
 
 
-version='0.2rc1'
+version='0.2rc1+1'
 
 long_description = read_file('README.rst') + '\n\n' + read_file('CHANGES.rst') 
 


### PR DESCRIPTION
Hi,

referring to http://github.com/dinoboff/github-tools/issues/#issue/19

This pull request should apply cleanly to mastser. The PyPi version is increased plus hopefully everything added (README, CHANGES, ...) that should be there. Based on: http://github.com/mdornseif/github-tools/commit/a35be1ed26fcafc643c64d86e3ead6e099985ad7 which actually fixes the requirements...

(Sorry couldn't help myself I just hate trailing whitespace, but at least I made the commit obvious) :)
http://github.com/serverhorror/github-tools/commit/583d919806ea022a0cc49d9be218426190b0cc7c
